### PR TITLE
Add initial unit tests

### DIFF
--- a/tests/Unit/Events/TicketEventTest.php
+++ b/tests/Unit/Events/TicketEventTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Events\TicketCreated;
+use App\Events\TicketStatusChange;
+use App\Events\TicketUpdated;
+use App\Events\TicketDeleted;
+use App\Events\TicketMessageSent;
+use App\Models\Ticket\TicketMessage;
+use App\Models\Ticket\Ticket;
+use Illuminate\Broadcasting\PrivateChannel;
+
+it('ticket created event has correct broadcast name and queue', function () {
+    $event = new TicketCreated(1, 1);
+    expect($event->broadcastAs())->toBe('ticket.created')
+        ->and($event->broadcastQueue())->toBe('broadcasts');
+});
+
+it('ticket status change event has correct broadcast name and queue', function () {
+    $event = new TicketStatusChange(1, 1, []);
+    expect($event->broadcastAs())->toBe('ticket.status.change')
+        ->and($event->broadcastQueue())->toBe('broadcasts');
+});
+
+it('ticket updated event has correct broadcast name and queue', function () {
+    $event = new TicketUpdated(1, 1, []);
+    expect($event->broadcastAs())->toBe('ticket.updated')
+        ->and($event->broadcastQueue())->toBe('broadcasts');
+});
+
+it('ticket deleted event has correct broadcast name and queue', function () {
+    $data = ['id' => 1, 'created_by' => ['id' => 1], 'accepted_by' => ['id' => 2]];
+    $event = new TicketDeleted($data, 1);
+    expect($event->broadcastAs())->toBe('ticket.deleted')
+        ->and($event->broadcastQueue())->toBe('broadcasts');
+});
+
+it('ticket message sent event channels exclude sender', function () {
+    $ticket = new Ticket();
+    $ticket->created_by = 1;
+    $ticket->accepted_by = 2;
+    $message = new TicketMessage(['sender_id' => 1]);
+    $message->setRelation('ticket', $ticket);
+
+    $event = new TicketMessageSent($message, 5);
+    $channels = $event->broadcastOn();
+
+    expect($channels)->toHaveCount(1)
+        ->and($channels[0])->toBeInstanceOf(PrivateChannel::class)
+        ->and($channels[0]->name)->toBe('tenant-5.user-2');
+});
+

--- a/tests/Unit/FormRequestTest.php
+++ b/tests/Unit/FormRequestTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Http\Requests\RegisterUserRequest;
+use App\Http\Requests\RegisterTenantRequest;
+use App\Http\Requests\UpdateProfileRequest;
+
+it('register user request contains expected rules', function () {
+    $request = new RegisterUserRequest();
+    $rules = $request->rules();
+
+    expect($rules)->toHaveKeys(['name', 'email', 'password', 'phone_number']);
+});
+
+it('register tenant request contains expected rules', function () {
+    $request = new RegisterTenantRequest();
+    $rules = $request->rules();
+
+    expect($rules)->toHaveKeys(['company_name', 'sub_domain', 'password', 'remember']);
+});
+
+it('update profile request contains expected rules', function () {
+    $request = new UpdateProfileRequest();
+    $rules = $request->rules();
+
+    expect($rules)->toHaveKeys(['name', 'email', 'password']);
+});
+

--- a/tests/Unit/Models/TicketMessageModelTest.php
+++ b/tests/Unit/Models/TicketMessageModelTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Models\Ticket\TicketMessage;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+it('belongs to a ticket', function () {
+    $message = new TicketMessage();
+    expect($message->ticket())->toBeInstanceOf(BelongsTo::class);
+});
+
+it('belongs to a sender', function () {
+    $message = new TicketMessage();
+    expect($message->sender())->toBeInstanceOf(BelongsTo::class);
+});
+

--- a/tests/Unit/Models/TicketModelTest.php
+++ b/tests/Unit/Models/TicketModelTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Ticket\Ticket;
+use App\Models\Ticket\TicketAttachment;
+use App\Models\Ticket\TicketLevel;
+use App\Models\Ticket\TicketStatus;
+use App\Models\Ticket\TicketType;
+use App\Models\Ticket\TicketMessage;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+it('has a status relation', function () {
+    $ticket = new Ticket();
+    expect($ticket->status())->toBeInstanceOf(BelongsTo::class);
+});
+
+it('has a level relation', function () {
+    $ticket = new Ticket();
+    expect($ticket->level())->toBeInstanceOf(BelongsTo::class);
+});
+
+it('has a type relation', function () {
+    $ticket = new Ticket();
+    expect($ticket->type())->toBeInstanceOf(BelongsTo::class);
+});
+
+it('has attachments relation', function () {
+    $ticket = new Ticket();
+    expect($ticket->attachments())->toBeInstanceOf(HasMany::class);
+});
+
+it('has createdBy relation', function () {
+    $ticket = new Ticket();
+    expect($ticket->createdBy())->toBeInstanceOf(BelongsTo::class);
+});
+
+it('has acceptedBy relation', function () {
+    $ticket = new Ticket();
+    expect($ticket->acceptedBy())->toBeInstanceOf(BelongsTo::class);
+});
+
+it('has messages relation', function () {
+    $ticket = new Ticket();
+    expect($ticket->messages())->toBeInstanceOf(HasMany::class);
+});
+

--- a/tests/Unit/Models/UserModelTest.php
+++ b/tests/Unit/Models/UserModelTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+it('has tickets relation', function () {
+    $user = new User();
+    expect($user->tickets())->toBeInstanceOf(HasMany::class);
+});
+
+it('has attachments relation', function () {
+    $user = new User();
+    expect($user->attachments())->toBeInstanceOf(HasMany::class);
+});
+
+it('has messages relation', function () {
+    $user = new User();
+    expect($user->messages())->toBeInstanceOf(HasMany::class);
+});
+


### PR DESCRIPTION
## Summary
- cover model relationships for Ticket, TicketMessage and User models
- test basic form request rule definitions
- validate event broadcast properties and channel logic

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6f145af0832d954ffa2b3f1bb2ec